### PR TITLE
[FEAT] 검색 후 화면 퍼블리싱

### DIFF
--- a/pages/search/[result].tsx
+++ b/pages/search/[result].tsx
@@ -1,5 +1,6 @@
 import SearchBar from '@/components/common/SearchBar';
 import COLOR from '@/constants/colors';
+import FONT from '@/constants/fonts';
 import { GetServerSideProps } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -8,27 +9,29 @@ import styled from 'styled-components';
 
 const SearchResultIndex = ({ result }: { result: string }) => {
   const router = useRouter();
-
   const [searchResult, setSearchResult] = useState<string>('');
   const [searchList, setSearchList] = useState([
     {
       id: '0',
       name: '국립 고궁 박물관',
       type: '박물관',
-      location: '서울 종로구 세종로'
+      location: '서울 종로구 세종로',
+      startTimeAt: '10:00'
     },
     {
       id: '1',
       name: '국립 현대 미술관',
       type: '미술관',
-      location: '서울 종로구 소격동'
+      location: '서울 종로구 소격동',
+      startTimeAt: '9:30'
     },
 
     {
       id: '2',
       name: '진격의 거인전',
       type: '전시회',
-      location: '서울 마포구 서교동'
+      location: '서울 마포구 서교동',
+      startTimeAt: '10:30'
     }
   ]);
 
@@ -39,47 +42,31 @@ const SearchResultIndex = ({ result }: { result: string }) => {
   return (
     <>
       <SearchBar text={result} />
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          borderBottom: '1px solid black',
-          borderColor: COLOR.LINE
-        }}
-      >
+      <div>
         {searchList.map((result) => (
-          <div
-            key={result.id}
-            style={{ display: 'flex', borderBottom: '1px solid black', borderColor: COLOR.LINE }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                flexBasis: '80%',
-                flexDirection: 'column',
-                gap: 10,
-                padding: 20
-              }}
-            >
-              <div style={{ display: 'flex', gap: 10 }}>
-                <div>{result.name}</div>
-                <div>{result.type}</div>
-              </div>
-              <div>{result.location}</div>
-              <div style={{ display: 'flex', gap: 10 }}>
-                <div>운영종료</div>
-                <div>10:00시에 운영시작</div>
-              </div>
+          <SearchListWrapper key={result.id}>
+            <LeftWrapper>
+              <PlaceHeadWrapper>
+                <PlaceName style={FONT.HEADLINE2}>{result.name}</PlaceName>
+                <PlaceType style={FONT.BODY2} type={result.type}>
+                  {result.type}
+                </PlaceType>
+              </PlaceHeadWrapper>
+              <PlaceLocation style={FONT.BODY2}>{result.location}</PlaceLocation>
+              <PlaceTimeWrapper style={FONT.BODY2}>
+                <div style={{ color: COLOR.RED }}>운영종료</div>
+                <div>{result.startTimeAt} 에 운영시작</div>
+              </PlaceTimeWrapper>
               <IconWrapper>
                 <Image src='/images/wheelChair.svg' width={30} height={30} />
                 <Image src='/images/elevator.svg' width={30} height={30} />
                 <Image src='/images/slope.svg' width={30} height={30} />
               </IconWrapper>
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center' }}>
+            </LeftWrapper>
+            <RightWrapper>
               <RouteButton>길찾기</RouteButton>
-            </div>
-          </div>
+            </RightWrapper>
+          </SearchListWrapper>
         ))}
       </div>
     </>
@@ -100,6 +87,54 @@ const IconWrapper = styled.div`
   gap: 5px;
 `;
 
+const LeftWrapper = styled.div`
+  display: flex;
+  flex-basis: 80%;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px;
+`;
+
+interface PlaceTypeProps {
+  type: string;
+}
+
+type ObjType = {
+  [index: string]: string;
+};
+
+const TYPE_TO_COLOR: ObjType = {
+  박물관: COLOR.ORANGE,
+  미술관: COLOR.GREEN,
+  전시회: COLOR.RED
+};
+
+const PlaceType = styled.div<PlaceTypeProps>`
+  color: ${(props) => TYPE_TO_COLOR[props.type]};
+`;
+
+const PlaceHeadWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const PlaceName = styled.div``;
+
+const PlaceLocation = styled.div`
+  color: ${COLOR.GREY};
+`;
+
+const PlaceTimeWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+  color: ${COLOR.GREY};
+`;
+
+const RightWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
 const RouteButton = styled.div`
   background-color: ${COLOR.BLUE1};
   color: white;
@@ -110,6 +145,13 @@ const RouteButton = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
+`;
+
+const SearchListWrapper = styled.div`
+  display: flex;
+  border-bottom: 1px solid black;
+  border-color: ${COLOR.LINE};
 `;
 
 export default SearchResultIndex;

--- a/pages/search/[result].tsx
+++ b/pages/search/[result].tsx
@@ -1,13 +1,20 @@
+import SearchBar from '@/components/common/SearchBar';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 const SearchResultIndex = () => {
   const router = useRouter();
 
+  const [searchResult, setSearchResult] = useState<string>('');
+
   useEffect(() => {
-    console.log(router.query.result);
+    if (typeof router.query.result === 'string') setSearchResult(router.query.result);
   });
-  return <div>{'' || router.query.result}</div>;
+  return (
+    <>
+      <SearchBar text={router.query.result} />
+    </>
+  );
 };
 
 export default SearchResultIndex;

--- a/pages/search/[result].tsx
+++ b/pages/search/[result].tsx
@@ -1,52 +1,97 @@
 import SearchBar from '@/components/common/SearchBar';
 import COLOR from '@/constants/colors';
+import { GetServerSideProps } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-const SearchResultIndex = () => {
+const SearchResultIndex = ({ result }: { result: string }) => {
   const router = useRouter();
 
   const [searchResult, setSearchResult] = useState<string>('');
+  const [searchList, setSearchList] = useState([
+    {
+      id: '0',
+      name: '국립 고궁 박물관',
+      type: '박물관',
+      location: '서울 종로구 세종로'
+    },
+    {
+      id: '1',
+      name: '국립 현대 미술관',
+      type: '미술관',
+      location: '서울 종로구 소격동'
+    },
+
+    {
+      id: '2',
+      name: '진격의 거인전',
+      type: '전시회',
+      location: '서울 마포구 서교동'
+    }
+  ]);
 
   useEffect(() => {
-    if (typeof router.query.result === 'string') setSearchResult(router.query.result);
-  });
+    setSearchResult(result);
+  }, [result]);
+
   return (
     <>
-      <SearchBar text={router.query.result} />
-      <div style={{ display: 'flex', borderBottom: '1px solid black' }}>
-        <div
-          style={{
-            display: 'flex',
-            flexBasis: '80%',
-            flexDirection: 'column',
-            gap: 10,
-            padding: 20
-          }}
-        >
-          <div style={{ display: 'flex', gap: 10 }}>
-            <div>국립고궁 박물관</div>
-            <div>박물관</div>
+      <SearchBar text={result} />
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          borderBottom: '1px solid black',
+          borderColor: COLOR.LINE
+        }}
+      >
+        {searchList.map((result) => (
+          <div
+            key={result.id}
+            style={{ display: 'flex', borderBottom: '1px solid black', borderColor: COLOR.LINE }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                flexBasis: '80%',
+                flexDirection: 'column',
+                gap: 10,
+                padding: 20
+              }}
+            >
+              <div style={{ display: 'flex', gap: 10 }}>
+                <div>{result.name}</div>
+                <div>{result.type}</div>
+              </div>
+              <div>{result.location}</div>
+              <div style={{ display: 'flex', gap: 10 }}>
+                <div>운영종료</div>
+                <div>10:00시에 운영시작</div>
+              </div>
+              <IconWrapper>
+                <Image src='/images/wheelChair.svg' width={30} height={30} />
+                <Image src='/images/elevator.svg' width={30} height={30} />
+                <Image src='/images/slope.svg' width={30} height={30} />
+              </IconWrapper>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              <RouteButton>길찾기</RouteButton>
+            </div>
           </div>
-          <div>서울 종로구 세종로</div>
-          <div style={{ display: 'flex' }}>
-            <div>운영종료</div>
-            <div>10:00시에 운영시작</div>
-          </div>
-          <IconWrapper>
-            <Image src='/images/wheelChair.svg' width={30} height={30} />
-            <Image src='/images/elevator.svg' width={30} height={30} />
-            <Image src='/images/slope.svg' width={30} height={30} />
-          </IconWrapper>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <RouteButton>길찾기</RouteButton>
-        </div>
+        ))}
       </div>
     </>
   );
+};
+
+export const getServerSideProps = async ({ query: { result } }: { query: { result: string } }) => {
+  // fetching data here
+  // Return the data as props
+  return {
+    props: { result }
+  };
 };
 
 const IconWrapper = styled.div`

--- a/pages/search/[result].tsx
+++ b/pages/search/[result].tsx
@@ -1,6 +1,9 @@
 import SearchBar from '@/components/common/SearchBar';
+import COLOR from '@/constants/colors';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 
 const SearchResultIndex = () => {
   const router = useRouter();
@@ -13,8 +16,55 @@ const SearchResultIndex = () => {
   return (
     <>
       <SearchBar text={router.query.result} />
+      <div style={{ display: 'flex', borderBottom: '1px solid black' }}>
+        <div
+          style={{
+            display: 'flex',
+            flexBasis: '80%',
+            flexDirection: 'column',
+            gap: 10,
+            padding: 20
+          }}
+        >
+          <div style={{ display: 'flex', gap: 10 }}>
+            <div>국립고궁 박물관</div>
+            <div>박물관</div>
+          </div>
+          <div>서울 종로구 세종로</div>
+          <div style={{ display: 'flex' }}>
+            <div>운영종료</div>
+            <div>10:00시에 운영시작</div>
+          </div>
+          <IconWrapper>
+            <Image src='/images/wheelChair.svg' width={30} height={30} />
+            <Image src='/images/elevator.svg' width={30} height={30} />
+            <Image src='/images/slope.svg' width={30} height={30} />
+          </IconWrapper>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <RouteButton>길찾기</RouteButton>
+        </div>
+      </div>
     </>
   );
 };
+
+const IconWrapper = styled.div`
+  display: flex;
+  flexbasis: 20%;
+  gap: 5px;
+`;
+
+const RouteButton = styled.div`
+  background-color: ${COLOR.BLUE1};
+  color: white;
+  padding: 10px;
+  width: 20%
+  height: 10px;
+  border-radius: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 export default SearchResultIndex;

--- a/pages/search/index.tsx
+++ b/pages/search/index.tsx
@@ -1,50 +1,20 @@
+import SearchBar from '@/components/common/SearchBar';
 import COLOR from '@/constants/colors';
 import FONT from '@/constants/fonts';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { AiOutlineClose, AiOutlineSearch } from 'react-icons/ai';
-import { BsArrowLeft } from 'react-icons/bs';
+import { AiOutlineClose } from 'react-icons/ai';
 import styled from 'styled-components';
 
 const Search = () => {
-  const router = useRouter();
-
-  const [inputText, setInputText] = useState<string>('');
-
   const [searchList, setSearchList] = useState([
     { id: '0', name: '국립 고궁 박물관' },
     { id: '1', name: '국립 현대 미술관' },
     { id: '2', name: '진격의 거인전' }
   ]);
 
-  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputText(e.target.value);
-  };
   return (
     <SearchWrapper>
-      <SearchInputWrapper>
-        <div style={{ display: 'flex', gap: 10 }}>
-          <BsArrowLeft color={COLOR.GREY} size={25} />
-          <SearchInput
-            placeholder='검색어를 입력하세요.'
-            value={inputText}
-            onChange={handleChangeInput}
-          />
-        </div>
-        <SearchButton
-          onClick={() =>
-            router.push(
-              {
-                pathname: '/search/[result]',
-                query: { result: inputText }
-              },
-              '/result'
-            )
-          }
-        >
-          <AiOutlineSearch size={30} color={COLOR.GREY} />
-        </SearchButton>
-      </SearchInputWrapper>
+      <SearchBar />
       <div>
         {searchList.map((result) => (
           <SearchResult style={FONT.BODY1}>
@@ -61,31 +31,6 @@ const SearchWrapper = styled.div`
   display: flex;
   flex-direction: column;
   border: 1px solid black;
-`;
-
-const SearchInputWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  height: 10vh;
-  padding: 10px;
-  border-bottom: 1px solid black;
-  border-color: ${COLOR.LINE};
-`;
-
-const SearchInput = styled.input`
-  border: 0;
-  padding-right: 65%;
-  font-size: 16px;
-  &::placeholder {
-    color: ${COLOR.GREY};
-  }
-`;
-
-const SearchButton = styled.div`
-  display: flex;
-  cursor: pointer;
 `;
 
 const SearchResult = styled.div`

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -45,7 +45,7 @@ const SearchBar = ({ text }: ISearchBar) => {
                 pathname: '/search/[result]',
                 query: { result: inputText }
               },
-              '/result'
+              `/search?result=${inputText}`
             )
           }
         >

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,0 +1,77 @@
+import COLOR from '@/constants/colors';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { styled } from 'styled-components';
+import { AiOutlineClose, AiOutlineSearch } from 'react-icons/ai';
+import { BsArrowLeft } from 'react-icons/bs';
+
+interface ISearchBar {
+  text?: string | string[];
+}
+
+const SearchBar = ({ text }: ISearchBar) => {
+  const router = useRouter();
+
+  const [inputText, setInputText] = useState<string>('');
+
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputText(e.target.value);
+  };
+
+  useEffect(() => {
+    if (typeof text === 'string') setInputText(text);
+  }, []);
+
+  return (
+    <SearchInputWrapper>
+      <div style={{ display: 'flex', gap: 10 }}>
+        <BsArrowLeft color={COLOR.GREY} size={25} />
+        <SearchInput
+          placeholder='검색어를 입력하세요.'
+          value={inputText}
+          onChange={handleChangeInput}
+        />
+      </div>
+      <SearchButton
+        onClick={() =>
+          router.push(
+            {
+              pathname: '/search/[result]',
+              query: { result: inputText }
+            },
+            '/result'
+          )
+        }
+      >
+        <AiOutlineSearch size={30} color={COLOR.GREY} />
+      </SearchButton>
+    </SearchInputWrapper>
+  );
+};
+
+const SearchInputWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 10vh;
+  padding: 10px;
+  border-bottom: 1px solid black;
+  border-color: ${COLOR.LINE};
+`;
+
+const SearchInput = styled.input`
+  border: 0;
+  padding-right: 65%;
+  font-size: 16px;
+  &::placeholder {
+    color: ${COLOR.GREY};
+  }
+`;
+
+const SearchButton = styled.div`
+  display: flex;
+  cursor: pointer;
+`;
+
+export default SearchBar;

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import { AiOutlineClose, AiOutlineSearch } from 'react-icons/ai';
 import { BsArrowLeft } from 'react-icons/bs';
+import Link from 'next/link';
 
 interface ISearchBar {
   text?: string | string[];
@@ -32,19 +33,25 @@ const SearchBar = ({ text }: ISearchBar) => {
           onChange={handleChangeInput}
         />
       </div>
-      <SearchButton
-        onClick={() =>
-          router.push(
-            {
-              pathname: '/search/[result]',
-              query: { result: inputText }
-            },
-            '/result'
-          )
-        }
-      >
-        <AiOutlineSearch size={30} color={COLOR.GREY} />
-      </SearchButton>
+      {text ? (
+        <Link href='/search'>
+          <AiOutlineClose size={30} color={COLOR.GREY} />
+        </Link>
+      ) : (
+        <SearchButton
+          onClick={() =>
+            router.push(
+              {
+                pathname: '/search/[result]',
+                query: { result: inputText }
+              },
+              '/result'
+            )
+          }
+        >
+          <AiOutlineSearch size={30} color={COLOR.GREY} />
+        </SearchButton>
+      )}
     </SearchInputWrapper>
   );
 };


### PR DESCRIPTION
🚩 관련 이슈
ex) [FEAT] #11 - 검색 후 화면 퍼블리싱

📋 PR Checklist

-  페이지 전환 후 검색결과가 인풋창에 그대로 들어가도록 구현
- SearchBar 분리
- 퍼블리싱

📌 유의사항
✅ 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브

<img width="1086" alt="image" src="https://github.com/BFGGyu/BF-frontend/assets/63959171/67c9150d-356d-47de-ac47-c8be5c3c9fb9">

